### PR TITLE
Octopus Deploy updated image versions

### DIFF
--- a/helm-charts/seascape-core/values-prod.yaml
+++ b/helm-charts/seascape-core/values-prod.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: IfNotPresent
   repository: harrisonmeister/seascape-core
-  tag: "2026.03.26.94"
+  tag: "2026.04.02.98"
   
 ingress:
   enabled: false


### PR DESCRIPTION
---
Images updated:
- index.docker.io/harrisonmeister/seascape-core:2026.04.02.98